### PR TITLE
Update workflow to publish to npm if git tag

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -2,24 +2,27 @@ on:
   push:
     tags: v*.*.*
 
-steps:
-- uses: actions/checkout@master
+jobs:
+  npm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
 
-- uses: actions/setup-node@v1
-  with:
-    node-version: '10.x'
-    registry-url: 'https://registry.npmjs.org'
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+        registry-url: 'https://registry.npmjs.org'
 
-- name: Install npm dependencies
-  run: npm install
+    - name: Install npm dependencies
+      run: npm install
 
-- name: Test and build package
-  run: |
-    npm test
-    npm run build
+    - name: Test and build package
+      run: |
+        npm test
+        npm run build
 
-- name: Publish tag to npm
-  if: contains(github.ref, 'tags')
-  run: npm publish
-  env:
-    NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+    - name: Publish tag to npm
+      if: contains(github.ref, 'tags')
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
[GitHub check is throwing error](https://github.com/voorhoede/vue-dato-image/pull/3/checks?check_run_id=213487867):
> `tags` is not a valid event name

[According to the GitHub docs](https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requesttagsbranches) this should be:
```
on:
  push:
    branches: 
    tags: v*
```

However as [community points out this doesn't work](https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requesttagsbranches).

[Zeit resolves this problem by using an `if` statement](https://zeit.co/blog/upgrading-to-latest-github-actions):
```
steps
  - name: publish
    if: contains(github.ref, 'tags')
    run: ...
```

This PR combines both solutions.