### PR TITLE
Fix: prevent changing defaults on imageUrl invocation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'vue',
   ],
   rules: {
-    semi: 'off'
+    'prefer-object-spread': 'off',
+    semi: 'off',
   },
 };

--- a/src/lib/image-url.js
+++ b/src/lib/image-url.js
@@ -13,9 +13,9 @@ const defaults = {
 /**
  * Format image URL
  *
- * @param {string} imagePath    - Image base url. Must end with with `?`.
+ * @param {string} imagePath    - Image base url without query string (no ?param=...).
  * @param {Object} [params]     - Imgix manipulation parameters, see https://docs.imgix.com/apis/url
  */
-const imageUrl = (imagePath, params) => `${imagePath}?${stringify(Object.assign(defaults, params))}`
+const imageUrl = (imagePath, params) => `${imagePath}?${stringify(Object.assign({}, defaults, params))}`
 
 export default imageUrl

--- a/src/lib/image-url.test.js
+++ b/src/lib/image-url.test.js
@@ -14,3 +14,13 @@ test('Adds parameter object as query string', () => {
 
   expect(constructedURl).toEqual(`${url}?auto=compress&auto=quality&height=100&width=200`)
 })
+
+// test introduced for https://github.com/voorhoede/vue-dato-image/issues/72
+test('Uses clean defaults on every invocation', () => {
+  const url = 'https://www.datocms-assets.com/6524/1559739750-quantum-inspire-editor.jpg'
+  const url1 = imageUrl(url, { width: 200, height: 100, fm: 'webp' })
+  const url2 = imageUrl(url, { width: 200, height: 100 })
+
+  expect(url1).toEqual(`${url}?auto=compress&auto=quality&fm=webp&height=100&width=200`)
+  expect(url2).toEqual(`${url}?auto=compress&auto=quality&height=100&width=200`)
+})


### PR DESCRIPTION
Resolves https://github.com/voorhoede/vue-dato-image/issues/72

**Cause:**
Within `VueDatoImage` the [`imageUrl()` function is called for both `<source>` elements, the first time with `{ fm: 'webp' }` and the second time without](https://github.com/voorhoede/vue-dato-image/blob/master/src/vue-dato-image.vue#L20-L21). Internally [`imageUrl` uses `Object.assign(defaults, params)`](https://github.com/voorhoede/vue-dato-image/commit/1a4e2104f6ceab797f0068f90d42abd9cb0f6b42#diff-0b668c24b4edb86aee349ae7d031a3ceR19) which changes the `defaults`.

**Fix:**
This PR uses `Object.assign({}, defaults, params)`.

Images on https://deploy-preview-73--vue-dato-image.netlify.app/v1/ now also load in Safari:

![Screen Shot 2020-07-16 at 15 09 19](https://user-images.githubusercontent.com/1516059/87674490-5c7d3800-c776-11ea-8b42-97dfbc330586.jpg)

